### PR TITLE
Fixvar

### DIFF
--- a/conf.d/paths.fish
+++ b/conf.d/paths.fish
@@ -16,7 +16,7 @@ end
 
 for file in "$fish/paths.d"/*
     if test -s "$file"
-        set -l name (string split -rm1 / "$file")[-1]
+        set -l name (command basename "$file")
         read -laz values < "$file"
 
         if test "$name" = PATH


### PR DESCRIPTION
Hello, 

I noticed this plugin had a weird bug on the addition of new environment variables.  It would add the `$name` and the `$values` to the `$name` variable. At the same time, the variable fetch on Linux should be run as `basename` to get the filename from the path location. I have added both these changes in separate commits for ease in integration. Hopefully the helps out on this excellent extender of fish. :)