### PR TITLE
A 2.2 fix to variable expansion #2

### DIFF
--- a/conf.d/paths.fish
+++ b/conf.d/paths.fish
@@ -14,6 +14,11 @@ if test ! -d "$fish/paths.d"
     command mkdir -p "$fish/paths.d"
 end
 
+function __paths_tildefy -d "alias ~/ $HOME to their expansions"
+    set -l real_home ~
+    printf "%s\n" $argv | sed "s,~,$HOME,g;s,\$HOME,$HOME,g"
+end
+
 for file in "$fish/paths.d"/*
     if test -s "$file"
         set -l name (command basename "$file")
@@ -21,12 +26,16 @@ for file in "$fish/paths.d"/*
 
         if test "$name" = PATH
             for value in $values
+                set -l  value (__paths_tildefy $value)
                 if test -e "$value"
                     set -gx PATH $PATH $value
                 end
             end
         else
+            set -l values (__paths_tildefy $values)
             set -gx "$name" $$name $values
         end
     end
 end
+
+functions __paths_tildefy -e


### PR DESCRIPTION
After a little bit more usage, I think the best way to deal with the [variable expansion][1] is to have a fix with replacing `$HOME` and `~/` literally instead of through fish. I propose (in the same idea as the previous PR), to temporarily have an expansion literal for only `$HOME` and `~/` until 2.3 release, where the **string** command is available. Doing so would allow us to have a temporary fix to the issue until stable. (Also, it let's me perfect the **string** usage...)

Right now, I noticed how handicapped we truly are without the 2.3 **string** command. It's actually remarkably powerful and makes me ever more appreciative to have discovered fish.  Anyway, the **string** command would allow for a better approach to variable expansion issue, without worrying of the out sourced tools for doing so.  Right now, this is the best approach to the issue I could come up, without using too much foreign commands.



[1]: https://github.com/fisherman/paths/issues/2