### PR TITLE
removing append for ease of use #4

### DIFF
--- a/conf.d/paths.fish
+++ b/conf.d/paths.fish
@@ -26,7 +26,7 @@ for file in "$fish/paths.d"/*
                 end
             end
         else
-            set -gx "$name" $$name $values
+            set -gx "$name" $values
         end
     end
 end


### PR DESCRIPTION
As explained on issue  https://github.com/fisherman/paths/issues/4,

The extend factor on the declaration can be remedied with removing `$$name` from the assignment. 