### PR TITLE
FIX #6: values containing white space

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Create or append to environment variables.
 
 ```fish
 mkdir $paths_config/VAR
-echo VALUE > $paths_config/VAR/KEY
+echo VALUE >> $paths_config/VAR/KEY
 ```
 
 Where KEY is the name of the file that stores VAR's value and can be any name you wish.
@@ -44,7 +44,7 @@ Append to $PATH.
 
 ```fish
 mkdir $paths_config/PATH
-echo $GOPATH/bin > $paths_config/PATH/GOBIN
+echo $GOPATH/bin >> $paths_config/PATH/GOBIN
 ```
 
 [travis-link]: https://travis-ci.org/fisherman/paths

--- a/conf.d/paths.fish
+++ b/conf.d/paths.fish
@@ -38,8 +38,12 @@ switch "$FISH_VERSION"
                 set -l name (string split -rm1 / "$file")[-1]
 
                 for file in "$file"/*
-                    read -laz values < $file
-                    set -gx $name $$name $values
+                    for value in (string split \n < $file)
+                        set -l value_trimmed (string trim $value)
+                        if test -n $value_trimmed
+                            set -gx $name $$name $value_trimmed
+                        end
+                    end
                 end
 
             else if test -f "$file"


### PR DESCRIPTION
Make values in $paths_config/VAR/KEY line separated, so that value containing white space is working.

Example:
```
> cat $paths_config/PATH/test
/usr/local/bin
/path/with/white space/bin
```
will be parsed to two items in $PATH.